### PR TITLE
Bump req for signal-protocol 0.2.1 -> 0.2.2

### DIFF
--- a/journalist.py
+++ b/journalist.py
@@ -1,4 +1,5 @@
 import json
+import os
 import requests
 import time
 
@@ -6,9 +7,9 @@ PAUSE = 2
 
 from signal_protocol import address, curve, identity_key, storage, sealed_sender, session, session_cipher, state, protocol
 
-username = "journalist"
-passphrase = "this dont matter"
-totp = "123666"
+username = os.getenv("SECUREDROP_JOURNALIST_USERNAME", "journalist")
+passphrase = os.getenv("SECUREDROP_JOURNALIST_PASSPHRASE", "this dont matter")
+totp = os.getenv("SECUREDROP_JOURNALIST_TOTP", "123666")
 
 # Root endpoint
 resp = requests.get('http://127.0.0.1:8081/api/v2/')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-signal-protocol==0.2.1
+signal-protocol==0.2.2

--- a/source.py
+++ b/source.py
@@ -1,4 +1,5 @@
 import json
+import os
 import requests
 import time
 
@@ -7,7 +8,7 @@ PAUSE = 2
 from signal_protocol import address, curve, identity_key, state, storage, session, protocol, session_cipher
 
 # Copy a source codename from the dev console
-passphrase = "graceless limes fidgeting disjoin payee savanna uneasily wish"
+passphrase = os.getenv("SECUREDROP_SOURCE_CODENAME", "graceless limes fidgeting disjoin payee savanna uneasily wish")
 
 # Root endpoint
 resp = requests.get('http://127.0.0.1:8080/api/v2/')
@@ -112,7 +113,7 @@ session.process_prekey_bundle(
     new_pre_key_bundle,
 )
 
-original_message = "Hello I do declare I have some Interesting Deets about a Bad Thing"
+original_message = b"Hello I do declare I have some Interesting Deets about a Bad Thing"
 
 outgoing_message = session_cipher.message_encrypt(
     store, journalist_address, original_message


### PR DESCRIPTION
Required for latest sealed sender support. Otherwise, throws error:

Traceback (most recent call last):
  File "journalist.py", line 8, in <module>
    from signal_protocol import address, curve, identity_key, storage, sealed_sender, session, session_cipher, state, protocol
ImportError: cannot import name 'sealed_sender' from 'signal_protocol' (/home/user/.virtualenvs/e2e/lib/python3.7/site-packages/signal_protocol/__init__.py)

Pulls in changes including https://github.com/freedomofpress/signal-protocol/pull/19
Related, ensures that bytes are passed to message_encrypt.

Otherwise, errors as:

    Traceback (most recent call last):
      File "source.py", line 119, in <module>
        store, journalist_address, original_message
    TypeError: Can't convert 'Hello I do declare I have some Interesting Deets about a Bad Thing' to PyBytes

Finally, sprinkles in env-var support for the journalist & source
scripts, to make it a bit easier to plug in values ad-hoc from a dev
env.