### PR TITLE
`venv`: configures Python virtual environment for demo clients

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,11 @@ lint:
 .PHONY: test
 test:
 	cargo test
+
+.PHONY: venv
+venv:
+	python3 -m venv .venv
+	.venv/bin/pip install --upgrade pip
+	.venv/bin/pip install -r requirements.txt
+	@echo "#################"
+	@echo "Make sure to run: source .venv/bin/activate"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,16 @@ _prototype source + journalist clients for SecureDrop_
 ## Run the demo
 
 There are Python clients in `journalist.py` (user `journalist`) and `journalist2.py` (user `dellsberg`) to demo e2e communications through the server.
-To modify that Python client, simply install `requirements.txt`.
+
+To run or modify these Python clients, simply run:
+
+```sh-session
+$ make venv
+[...]
+#################
+Make sure to run: source .venv/bin/activate
+$ source .venv/bin/activate
+```
 
 To try out e2e encryption, complete the following steps:
 


### PR DESCRIPTION
This replicates the behavior of `make venv` in `freedomofpress/securedrop`
and `freedomofpress/securedrop-client` for a more-consistent developer
experience across projects.

## Testing

1. [ ] Follow the instructions in the [readme beginning "To run or modify these Python clients"](https://github.com/freedomofpress/securedrop-e2e/blob/3792c8fd19abac42a665b4065b911bc9523c839b/README.md?plain=1#L11-L19)
2. [ ] Confirm that the virtual environment is created, populated, and activated
3. [ ] Run `python journalist.py` and confirm that there are no `ImportError`s
4. [ ] Run `python journalist2.py` and confirm that there are no `ImportError`s